### PR TITLE
fix gcr buffer size

### DIFF
--- a/inc/common.h
+++ b/inc/common.h
@@ -1,10 +1,13 @@
 #pragma once
 #include "main.h"
 
+// 18 is the max buffer_padding selected in IO.c
+#define GCR_BUFFER_SIZE (23 + 18)
+
 extern uint8_t eepromBuffer[176];
 extern uint16_t TIMER1_MAX_ARR;
 
-extern uint32_t gcr[30];
+extern uint32_t gcr[GCR_BUFFER_SIZE];
 extern uint16_t adjusted_input;
 extern uint32_t dma_buffer[64];
 extern uint8_t dshotcommand;

--- a/src/dshot.c
+++ b/src/dshot.c
@@ -45,7 +45,7 @@ extern char play_tone_flag;
 uint8_t command_count = 0;
 uint8_t last_command = 0;
 uint8_t high_pin_count = 0;
-uint32_t gcr[30] =  {0};
+uint32_t gcr[GCR_BUFFER_SIZE] =  {0};
 uint16_t dshot_frametime;
 uint16_t dshot_goodcounts;
 uint16_t dshot_badcounts;


### PR DESCRIPTION
`sendDshotDma()` in IO.c sets up a dma transfer for `23 + buffer_padding` bytes.
the max `buffer_padding` configured in IO.c is 18, overflowing the current gcr buffer size of 30.